### PR TITLE
Fase de despliegue en Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,116 @@
+databases:
+  - name: cvflow-db
+    databaseName: cvflow
+    user: cvflow
+    plan: free   # cámbialo si necesitas más RAM
+
+services:
+  # ──────────────── Infra privada ────────────────
+  - name: rabbitmq
+    type: private
+    runtime: image
+    image: rabbitmq:3-management
+    envVars: []              # no necesita nada
+    ports: 5672
+    healthCheckPath: /       # Render exige uno; Rabbit devuelve “OK” en /html
+
+  - name: keycloak
+    type: web                # si vas a exponer login
+    runtime: image
+    image: quay.io/keycloak/keycloak:23.0
+    startCommand: start-dev
+    envVars:
+      - key: KEYCLOAK_ADMIN           # ⇢ fija valores en el panel
+        value: admin
+      - key: KEYCLOAK_ADMIN_PASSWORD
+        value: admin
+    ports: 8080
+    disk:
+      name: kc-data
+      mountPath: /opt/keycloak/data
+      sizeGB: 1
+
+  - name: mailhog
+    type: private
+    runtime: image
+    image: mailhog/mailhog:latest
+    ports: 1025                 # (la UI 8025 quedaría interna)
+
+  # ──────────────── Ollama/IA ────────────────
+  - name: ollama
+    type: private
+    runtime: docker
+    dockerfilePath: ai-ollama.Dockerfile
+    autoDeploy: false
+    ports: 11434
+
+  # ──────────────── Back‑end Spring ────────────────
+  - name: core-service
+    type: private
+    runtime: docker
+    dockerfilePath: core-service/Dockerfile
+    envVars:
+      - key: SPRING_DATASOURCE_URL
+        fromDatabase:
+          name: cvflow-db
+          property: connectionString
+      - key: SPRING_DATASOURCE_USERNAME
+        fromDatabase:
+          name: cvflow-db
+          property: user
+      - key: SPRING_DATASOURCE_PASSWORD
+        fromDatabase:
+          name: cvflow-db
+          property: password
+    ports: 8082
+
+  - name: ai-service
+    type: private
+    runtime: docker
+    dockerfilePath: ai-service/Dockerfile
+    envVars:
+      - key: SPRING_AI_OLLAMA_URL
+        value: http://ollama:11434
+      - key: SPRING_AI_OLLAMA_MODEL
+        value: llama3
+    ports: 8083
+    dependsOn:
+      - ollama
+
+  - name: cv-parser
+    type: private
+    runtime: docker
+    dockerfilePath: cv-parser/Dockerfile
+    healthCheckPath: /actuator/health
+    ports: 8085
+
+  # ──────────────── Gateway API ────────────────
+  - name: gateway
+    type: web
+    runtime: docker
+    dockerfilePath: gateway/Dockerfile
+    ports: 8080
+    envVars:
+      - key: SPRING_PROFILES_ACTIVE
+        value: prod
+    dependsOn:
+      - core-service
+      - ai-service
+      - cv-parser
+
+  # ──────────────── Angular Front ────────────────
+  - name: frontend
+    type: web
+    runtime: docker
+    dockerfilePath: frontend/Dockerfile
+    ports: 80
+    buildCommand: |
+      # si tu Dockerfile ya hace ng build, borra esta línea
+      echo "handled in Dockerfile"
+    staticPublishPath: /usr/share/nginx/html
+    dependsOn:
+      - gateway
+    headers:
+      - source: /*
+        headers:
+          - X-Frame-Options: DENY


### PR DESCRIPTION
# Despliegue de SmartCareerMate como demo pública en Render (Blueprint IaC)

Este PR añade un archivo **`render.yaml`** en la raíz del repositorio para describir, de forma declarativa (*Infrastructure as Code*), toda la infraestructura mínima necesaria para levantar una demo pública de SmartCareerMate en la plataforma Render: base de datos PostgreSQL, servicios internos (RabbitMQ, Keycloak, Mailhog), stack de IA (Ollama), microservicios backend (core, IA, parser de CVs), gateway API y frontend Angular.

---

## Contexto

Hasta ahora el proyecto se ha orquestado localmente con **Docker Compose**; para compartir una demo accesible externamente y facilitar entornos reproducibles, damos el salto a **Render Blueprints**, que permiten versionar la infraestructura junto con el código en Git y sincronizar cambios automáticamente tras cada *push*.

---

## Qué incluye este PR

- Nuevo archivo `render.yaml` con definición de:
  - **Base de datos PostgreSQL** (`cvflow-db`) en plan `free` (comentado que se incremente si hace falta más RAM).
  - **Servicios privados**: RabbitMQ, Mailhog.
  - **Servicio Keycloak** (tipo `web` para exponer login) con disco persistente y credenciales de *admin* de ejemplo.
  - **Stack IA**: servicio `ollama` desplegado vía Dockerfile propio; `autoDeploy: false` para evitar reprovisiones costosas por pulls de modelos grandes.
  - **Microservicios backend Spring Boot**: `core-service`, `ai-service` (apunta a Ollama), `cv-parser` (con *health check*).
  - **API Gateway** (tipo `web`, perfil `prod`, depende lógicamente de los backends).
  - **Frontend Angular** (tipo `web`, Nginx estático; `buildCommand` marcador si ya se construye en Dockerfile).
- Comentarios en línea dentro del YAML para guiar ajustes manuales (planes, variables, exposición de puertos, etc.).

---

## Mapa de servicios

| Servicio        | Tipo Render | Puerto expuesto | ¿Público? | Notas clave                                              |
|-----------------|------------|-----------------|-----------|----------------------------------------------------------|
| `cvflow-db`     | Postgres DB | —               | No        | Plan `free` por defecto                                  |
| `rabbitmq`      | Private     | 5672            | No        | UI de gestión NO expuesta                                |
| `keycloak`      | Web         | 8080            | Sí        | Disco 1 GB; credenciales dummy `admin/admin`             |
| `mailhog`       | Private     | 1025            | No        | UI 8025 queda interna                                    |
| `ollama`        | Private     | 11434           | No        | `autoDeploy: false`; requiere modelo                     |
| `core-service`  | Private     | 8082            | No        | Conexión a Postgres vía `fromDatabase`                   |
| `ai-service`    | Private     | 8083            | No        | Usa `SPRING_AI_OLLAMA_URL`                               |
| `cv-parser`     | Private     | 8085            | No        | *Health check* `/actuator/health`                        |
| `gateway`       | Web         | 8080            | Sí        | Perfil `prod`; puerta de entrada API                     |
| `frontend`      | Web         | 80              | Sí        | Publica Angular compilado en Nginx                       |

---

## Ajustes manuales necesarios antes de exponer la demo

1. **Cambiar credenciales de Keycloak**: los valores `KEYCLOAK_ADMIN` y `KEYCLOAK_ADMIN_PASSWORD` están configurados como `admin`; sustitúyelos antes de abrir el servicio al público.  
2. **Plan de la base de datos**: `free` es adecuado para pruebas ligeras pero limitado en RAM/IO; si la demo va a recibir más carga, sube de plan en el YAML o tras el primer *sync*.  
3. **Mailhog y RabbitMQ no expuestos**: si necesitas acceder a las UIs (p. ej. Mailhog 8025, RabbitMQ mgmt), crea servicios web separados, habilita acceso público o usa túneles/SSH.  
4. **Modelos en Ollama**: el contenedor se despliega pero no asegura que el modelo `llama3` esté descargado; añade un paso de inicialización o una imagen pre‑horneada con el modelo.  
5. **Build del Frontend**: el YAML incluye un `buildCommand` de marcador (`echo "handled in Dockerfile"`); confirma que el Dockerfile del frontend ejecuta `ng build --configuration=production`.

---

## Notas sobre dependencias / orden de despliegue

El archivo incluye claves `dependsOn` entre servicios (por ejemplo, `frontend` → `gateway`, `ai-service` → `ollama`). Actualmente **Render no garantiza un orden de build/deploy basado en dependencias declarativas**; usa *health checks*, *start scripts* o lógica de reintento en tus servicios para tolerar arranques desordenados.

---

## Cómo desplegar en Render

1. Haz *push* de esta rama (o *merge* a `main`) asegurándote de incluir `render.yaml` en la raíz del repo.  
2. En el **Render Dashboard**: **New → Blueprint** y conecta este repositorio/branch.  
3. Render mostrará un resumen de recursos a crear; revisa planes, variables y regiones antes de aplicar.  
4. Al aplicar, Render aprovisiona DB + servicios y hará deploys iniciales; posteriores *pushes* que modifiquen `render.yaml` disparan sincronizaciones (puedes desactivar **Auto Sync** si prefieres aplicar manualmente).

---

## Verificación post‑despliegue

1. Confirmar que la **DB Postgres** está accesible y que las credenciales inyectadas en `core-service` se resuelven (Render inyecta `connectionString`, `user`, `password` vía `fromDatabase`).  
2. Revisar logs de **core-service** y **ai-service** para ver que se conectan a sus dependencias; `ai-service` debe resolver `SPRING_AI_OLLAMA_URL=http://ollama:11434`.  
3. Chequear `cv-parser` *health endpoint* `/actuator/health` desde otra app dentro de la red privada o vía *shell* Render.  
4. Abrir el **gateway público** y verificar rutas básicas (p. ej. `/actuator/health` si está expuesto, o endpoints API).  
5. Acceder al **frontend público** y recorrer el flujo de subida de CV para validar conectividad extremo a extremo.

---

## Checklist antes de mergear

- [ ] Credenciales sensibles actualizadas en Render (no `admin/admin`).  
- [ ] Plan de DB confirmado (demo vs `>free`).  
- [ ] Imagen de Ollama probada con modelo requerido.  
- [ ] Frontend construye correctamente en Dockerfile (o ajustar `buildCommand`).  
- [ ] *Health checks* definidos donde proceda.  
- [ ] Documentar URL pública de la demo tras primer despliegue.

---

## Riesgos conocidos / Próximos pasos

- Sin control de orden de despliegue → los microservicios deben tolerar dependencias aún no listas.  
- Recursos gratuitos (*free tier*) pueden dormir o limitar rendimiento; monitorizar experiencia demo y escalar si hace falta.  
- Credenciales por defecto en Keycloak representan riesgo si se deja público sin cambio.

---

### Cómo probar localmente (recordatorio)

Para desarrollo local sigue existiendo `docker-compose.yml` con stack equivalente (Postgres, RabbitMQ, Keycloak, Mailhog, Ollama, microservicios, gateway y frontend); permite reproducir la demo antes de subir cambios a Render.

---

> _Si ves algo que deba ajustarse (nombres, planes, variables, salud, exposición de puertos), coméntalo en este PR y lo iteramos._
